### PR TITLE
feat: ✨ cors config at app factory config

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,5 +1,5 @@
 line-length = 100
-tab-size = 4
+indent-width = 4
 output-format = "text"
 
 select = ["E", "F", "Q", "I", "ANN", "ASYNC", "W", "S", "A"]
@@ -14,6 +14,10 @@ ignore = [
     # "F401"       # unused-import https://beta.ruff.rs/docs/rules/unused-import/
 ]
 
+extend-exclude = [
+    ".patches"
+]
+
 [flake8-quotes]
 docstring-quotes = "double"
 inline-quotes = "single"
@@ -25,15 +29,13 @@ mypy-init-return = true
 
 
 
-[per-file-ignores]
+[extend-per-file-ignores]
 # ignore in tests:
 #    S101 (use of assert)
 #    ANN201 (missing type annotation)
 #    E701 (multiple statements on one line)
+#    F401 (unused import)
 "**/**/test/*.py" =  ["S101", "ANN201", "E701"]
 "**/**/tests/*.py" = ["S101", "ANN201", "E701"]
 "**/**/test_*.py" =  ["S101", "ANN201", "E701"]
-
-
-[extend-per-file-ignores]
-"__init__.py" = ["F401"]
+# "__init__.py" = ["F401"]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,18 @@
             "justMyCode": false
         },
         {
-            "name": "Python: FastAPI",
+            "name": "FastAPI: Example",
+            "type": "python",
+            "request": "launch",
+            "module": "uvicorn",
+            "args": [
+                "example.app.main:app",
+                "--reload",
+            ],
+            "justMyCode": false
+        },
+        {
+            "name": "FastAPI: Test",
             "type": "python",
             "request": "launch",
             "module": "uvicorn",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,11 @@
 {
     "files.exclude": {
         // 📙 sub-libs
-        // "tools": true,
+        "tools": true,
 
         // ⚙️ config
-        // "**/**/*.code-workspace": true,
-        // "pyproject.toml": true,
+        "pyproject.toml": true,
+        "**/**/*.code-workspace": true,
         "poetry.lock": true,
         "poetry.toml": true,
 
@@ -15,17 +15,21 @@
         ".env": true,
 
         // 🧪 tests
-        // "tests": true,
+        "tests": true,
+        "htmlcov": true,
+        "coverage": true,
+        ".coverage": true,
 
         // 🗑️
-        // ".patches": true,
+        ".patches": true,
         ".venv": true,
-        // ".vscode": true,
+        ".vscode": true,
         ".ruff_cache": true,
         "**/**/__pycache__": true,
         ".git": true,
         ".gitignore": true,
         ".pytest_cache": true,
+        ".github": true,
 
         // 📝 docs
         // "**/**/README.md": true

--- a/example/app/main.py
+++ b/example/app/main.py
@@ -70,7 +70,10 @@ app = Pest.create(
     middleware=[
         Middleware(PureAsgiMiddleware),
         pest_middleware
-    ]
+    ],
+    cors={
+        'allow_origins': ['*'],
+    }
 )
 
 

--- a/pest/core/application.py
+++ b/pest/core/application.py
@@ -24,6 +24,9 @@ from starlette.middleware import Middleware
 from starlette.routing import BaseRoute
 from typing_extensions import Doc
 
+from pest.logging import log
+from pest.middleware.types import CorsOptions
+
 from ..metadata.types.module_meta import InjectionToken
 from ..middleware.base import (
     PestBaseHTTPMiddleware,
@@ -197,3 +200,12 @@ class PestApplication(FastAPI):
             return func
 
         return decorator
+
+    def enable_cors(self, **opts: Unpack[CorsOptions]) -> None:
+        from starlette.middleware.cors import CORSMiddleware
+
+        from ..middleware.types import DEFAULT_CORS_OPTIONS
+
+        log.debug(f'Enabling CORS with options: {DEFAULT_CORS_OPTIONS | opts}')
+
+        self.add_middleware(CORSMiddleware, **opts)

--- a/pest/core/common/__init__.py
+++ b/pest/core/common/__init__.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
 from inspect import isclass
-from pydoc import classname
 from typing import TypeGuard
 
 from pest.metadata.types._meta import PestType

--- a/pest/factory/__init__.py
+++ b/pest/factory/__init__.py
@@ -1,12 +1,9 @@
-from typing import Sequence, Unpack, cast
-
-from starlette.middleware import Middleware as StarletteMiddleware
+from typing import Unpack, cast
 
 from ..core.application import PestApplication
 from ..core.types.fastapi_params import FastAPIParams
 from ..logging import LoggingOptions, log
-from ..middleware.base import PestMwDispatcher
-from ..middleware.types import MiddlewareDef
+from ..middleware.types import CorsOptions, MiddlewareDef
 from ..utils.functions import getset
 from . import post_app, pre_app
 from .app_creator import make_app as make_app
@@ -18,22 +15,24 @@ class Pest:
         cls,
         root_module: type,
         *,
-        prefix: str = '',
-        middleware: Sequence[StarletteMiddleware | PestMwDispatcher] = [],
         logging: LoggingOptions | None = None,
+        middleware: MiddlewareDef = [],
+        prefix: str = '',
+        cors: CorsOptions | None = None,
         **fastapi_params: Unpack[FastAPIParams]
     ) -> PestApplication:
         """
         🐀 ⇝ creates and initializes a pest application
         #### Params
         - root_module: the root (entry point) module of the application
-        - prefix: the prefix for the application's routes
         - logging: logging options (needs `loguru` to be installed)
+        - middleware: a list of middlewares to be applied to the application
+        - prefix: the prefix for the application's routes
         """
         name = getset(cast(dict, fastapi_params), 'title', 'pest 🐀')
         log.info(f'Initializing {name}')
 
         pre_app.setup(logging=logging)
         app = make_app(fastapi_params, root_module, prefix=prefix, middleware=middleware)
-        app = post_app.setup(app)
+        app = post_app.setup(app, cors=cors)
         return app

--- a/pest/factory/post_app.py
+++ b/pest/factory/post_app.py
@@ -1,9 +1,20 @@
 from ..core.application import PestApplication
+from ..middleware.types import CorsOptions
 
 
 def setup(
-    app: PestApplication
+    app: PestApplication,
+    cors: CorsOptions | None = None
 ) -> PestApplication:
     """Initializes stuff that needs the app to already exist to be able to setup"""
+    __setup_cors(app, cors)
 
     return app
+
+
+def __setup_cors(app: PestApplication, cors: CorsOptions | None) -> None:
+    """Sets up CORS"""
+    if cors is None:
+        return
+
+    app.enable_cors(**cors)

--- a/pest/metadata/__init__.py
+++ b/pest/metadata/__init__.py
@@ -1,1 +1,3 @@
-from .meta import get_meta, get_meta_value, inject_metadata
+from .meta import get_meta as get_meta
+from .meta import get_meta_value as get_meta_value
+from .meta import inject_metadata as inject_metadata

--- a/pest/middleware/types.py
+++ b/pest/middleware/types.py
@@ -1,7 +1,60 @@
-from typing import Sequence, TypeAlias
+from typing import Sequence, TypeAlias, TypedDict
 
 from starlette.middleware import Middleware as StarletteMiddleware
 
 from .base import PestMwDispatcher
 
 MiddlewareDef: TypeAlias = Sequence[StarletteMiddleware | PestMwDispatcher]
+
+
+class CorsOptions(TypedDict, total=False):
+    allow_origins: list[str]
+    '''
+    Configures the `Access-Control-Allow-Origin`.
+
+    Expects a list of origins that should be allowed to make cross-origin requests, or `"*"`
+    to allow all origins.
+    '''
+    allow_methods: list[str]
+    '''
+    Configures the `Access-Control-Allow-Methods` header.
+
+    Expects a list of allowed HTTP methods as strings, e.g. `["GET", "POST", "PUT", "DELETE"]`.
+    Defaults to `["GET"]`
+    '''
+    allow_headers: list[str]
+    '''
+    Configures the `Access-Control-Allow-Headers` header.
+
+    Expects a list of allowed HTTP headers as strings, e.g. `["Content-Type", "Authorization"]`.
+    '''
+    allow_credentials: bool
+    '''
+    Configures the `Access-Control-Allow-Credentials` header.
+
+    Set to `True` to pass the header, otherwise it is omitted.
+    '''
+    allow_origin_regex: str
+    '''
+    Same as `allow_origins`, but expects a string that will be compiled to a regular expression
+    object in order to match the origin.
+    '''
+    expose_headers: list[str]
+    '''
+    Configures the `Access-Control-Expose-Headers` header.
+
+    Expects a list of HTTP headers as strings. If not specified, no custom headers are exposed.
+    '''
+    max_age: int
+    '''
+    Configures the `Access-Control-Max-Age` header.
+
+    Expects an integer. Defaults to `600` (10 min).
+    '''
+
+
+DEFAULT_CORS_OPTIONS: CorsOptions = {
+    'allow_methods': ['GET',],
+    'allow_credentials': False,
+    'max_age': 600,
+}


### PR DESCRIPTION
Adds cors config at app factory config (#3)

```python
app = Pest.create(
    AppModule,
    cors={
        'allow_origins': ['*'],
        ...
    }
)
```

or

```python
app = Pest.create(AppModule)

app.enable_cors(
    allow_origins=['*'],
    ...
)
```