### PR TITLE
feat: ✨ request-scoped injectable dependencies

### DIFF
--- a/pest/core/controller.py
+++ b/pest/core/controller.py
@@ -45,6 +45,7 @@ def routes_of(cls: type) -> list[APIRoute]:
 
 
 def module_of(cls: type) -> 'Module':
+    """🐀 ⇝ obtains the parent module of a `controller`"""
     if not issubclass(cls, Controller):
         raise PestException(NOT_CONTROLLER.format(cls=cls.__name__))
 

--- a/pest/core/handler.py
+++ b/pest/core/handler.py
@@ -7,6 +7,7 @@ from fastapi import Depends, Request
 from fastapi.routing import APIRoute
 
 from ..metadata.types.handler_meta import HandlerMeta
+from ..middleware.di import scope_from
 from ..utils.functions import clean_dict
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -77,7 +78,8 @@ class PestControllerInjector:
     async def __call__(self, request: Request) -> Any:
         """🐀 ⇝ returns the controller to be injected"""
         from .controller import module_of
+        scope = scope_from(request)
         module = module_of(self.token)
-        controller = module.get(self.token)
+        controller = module.get(self.token, scope)
 
         return controller

--- a/pest/exceptions/http/http.py
+++ b/pest/exceptions/http/http.py
@@ -56,6 +56,7 @@ class BadRequestException(PestHTTPException):
         detail: Any = None,
         headers: dict[str, Any] | None = None,
     ) -> None:
+        """🐀 ⇝ `400` Bad Request"""
         super().__init__(
             status_code=400,
             detail=detail,
@@ -78,6 +79,7 @@ class UnauthorizedException(PestHTTPException):
         detail: Any = None,
         headers: dict[str, Any] | None = None,
     ) -> None:
+        """🐀 ⇝ `401` Unauthorized"""
         super().__init__(
             status_code=401,
             detail=detail,
@@ -100,6 +102,7 @@ class ForbiddenException(PestHTTPException):
         detail: Any = None,
         headers: dict[str, Any] | None = None,
     ) -> None:
+        """🐀 ⇝ `403` Forbidden"""
         super().__init__(
             status_code=403,
             detail=detail,
@@ -120,6 +123,7 @@ class NotFoundException(PestHTTPException):
         detail: Any = None,
         headers: dict[str, Any] | None = None,
     ) -> None:
+        """🐀 ⇝ `404` Not Found"""
         super().__init__(
             status_code=404,
             detail=detail,
@@ -141,6 +145,7 @@ class MethodNotAllowedException(PestHTTPException):
         detail: Any = None,
         headers: dict[str, Any] | None = None,
     ) -> None:
+        """🐀 ⇝ `405` Method Not Allowed"""
         super().__init__(
             status_code=405,
             detail=detail,
@@ -162,6 +167,7 @@ class NotAcceptableException(PestHTTPException):
         detail: Any = None,
         headers: dict[str, Any] | None = None,
     ) -> None:
+        """🐀 ⇝ `406` Not Acceptable"""
         super().__init__(
             status_code=406,
             detail=detail,
@@ -183,6 +189,7 @@ class ProxyAuthenticationRequiredException(PestHTTPException):
         headers: dict[str, Any] | None = None,
         headers_: dict[str, Any] | None = None,
     ) -> None:
+        """🐀 ⇝ `407` Proxy Authentication Required"""
         super().__init__(
             status_code=407,
             detail=detail,
@@ -204,6 +211,7 @@ class RequestTimeoutException(PestHTTPException):
         detail: Any = None,
         headers: dict[str, Any] | None = None,
     ) -> None:
+        """🐀 ⇝ `408` Request Timeout"""
         super().__init__(
             status_code=408,
             detail=detail,
@@ -225,6 +233,7 @@ class ConflictException(PestHTTPException):
         detail: Any = None,
         headers: dict[str, Any] | None = None,
     ) -> None:
+        """🐀 ⇝ `409` Conflict"""
         super().__init__(
             status_code=409,
             detail=detail,
@@ -245,6 +254,7 @@ class GoneException(PestHTTPException):
         detail: Any = None,
         headers: dict[str, Any] | None = None,
     ) -> None:
+        """🐀 ⇝ `410` Gone"""
         super().__init__(
             status_code=410,
             detail=detail,
@@ -265,6 +275,7 @@ class PreconditionFailedException(PestHTTPException):
         detail: Any = None,
         headers: dict[str, Any] | None = None,
     ) -> None:
+        """🐀 ⇝ `412` Precondition Failed"""
         super().__init__(
             status_code=412,
             detail=detail,
@@ -286,6 +297,7 @@ class PayloadTooLargeException(PestHTTPException):
         detail: Any = None,
         headers: dict[str, Any] | None = None,
     ) -> None:
+        """🐀 ⇝ `413` Payload Too Large"""
         super().__init__(
             status_code=413,
             detail=detail,
@@ -308,6 +320,7 @@ class UnsupportedMediaTypeException(PestHTTPException):
         headers: dict[str, Any] | None = None,
         media_type: str | None = None,
     ) -> None:
+        """🐀 ⇝ `415` Unsupported Media Type"""
         super().__init__(
             status_code=415,
             detail=detail,
@@ -331,6 +344,7 @@ class ImATeapotException(PestHTTPException):
         detail: Any = None,
         headers: dict[str, Any] | None = None,
     ) -> None:
+        """🐀 ⇝ `418` I'm a teapot"""
         super().__init__(
             status_code=418,
             detail=detail,
@@ -351,6 +365,7 @@ class UnprocessableEntityException(PestHTTPException):
         detail: Any = None,
         headers: dict[str, Any] | None = None,
     ) -> None:
+        """🐀 ⇝ `422` Unprocessable Entity"""
         super().__init__(
             status_code=422,
             detail=detail,
@@ -374,6 +389,7 @@ class InternalServerErrorException(PestHTTPException):
         detail: Any = None,
         headers: dict[str, Any] | None = None,
     ) -> None:
+        """🐀 ⇝ `500` Internal Server Error"""
         super().__init__(
             status_code=500,
             detail=detail,
@@ -394,6 +410,7 @@ class NotImplementedException(PestHTTPException):
         detail: Any = None,
         headers: dict[str, Any] | None = None,
     ) -> None:
+        """🐀 ⇝ `501` Not Implemented"""
         super().__init__(
             status_code=501,
             detail=detail,
@@ -415,6 +432,7 @@ class BadGatewayException(PestHTTPException):
         detail: Any = None,
         headers: dict[str, Any] | None = None,
     ) -> None:
+        """🐀 ⇝ `502` Bad Gateway"""
         super().__init__(
             status_code=502,
             detail=detail,
@@ -435,6 +453,7 @@ class ServiceUnavailableException(PestHTTPException):
         detail: Any = None,
         headers: dict[str, Any] | None = None,
     ) -> None:
+        """🐀 ⇝ `503` Service Unavailable"""
         super().__init__(
             status_code=503,
             detail=detail,
@@ -456,6 +475,7 @@ class GatewayTimeoutException(PestHTTPException):
         detail: Any = None,
         headers: dict[str, Any] | None = None,
     ) -> None:
+        """🐀 ⇝ `504` Gateway Timeout"""
         super().__init__(
             status_code=504,
             detail=detail,
@@ -476,6 +496,7 @@ class HttpVersionNotSupportedException(PestHTTPException):
         detail: Any = None,
         headers: dict[str, Any] | None = None,
     ) -> None:
+        """🐀 ⇝ `505` HTTP Version Not Supported"""
         super().__init__(
             status_code=505,
             detail=detail,

--- a/pest/factory/__init__.py
+++ b/pest/factory/__init__.py
@@ -10,6 +10,7 @@ from .app_creator import make_app as make_app
 
 
 class Pest:
+    """🐀 ⇝ the main class of the framework, used to create and initialize a pest application"""
     @classmethod
     def create(
         cls,

--- a/pest/middleware/di.py
+++ b/pest/middleware/di.py
@@ -1,0 +1,26 @@
+
+from fastapi import Request, Response
+from rodi import ActivationScope
+from starlette.middleware.base import RequestResponseEndpoint
+
+SCOPE_KEY = '__di_scope__'
+'''🐀 ⇝ the key used to store the di activation scope in a request'''
+
+
+def scope_from(request: Request) -> ActivationScope | None:
+    """obtains the di activation scope from a request"""
+    return getattr(request.state, SCOPE_KEY, None)
+
+
+async def di_scope_middleware(request: Request, call_next: RequestResponseEndpoint) -> Response:
+    """
+    middleware that injects a di activation scope into the request. Allows the
+    injection of request-scoped dependencies into controllers, services and other
+    middlewares.
+    """
+
+    with ActivationScope() as scope:
+        if scope.scoped_services is not None:
+            setattr(request.state, SCOPE_KEY, scope)
+
+        return await call_next(request)

--- a/tests/cfg/app/modules/todo/module.py
+++ b/tests/cfg/app/modules/todo/module.py
@@ -1,5 +1,3 @@
-
-
 from pest.decorators.module import module
 
 from .controllers.todo_controller import TodoController

--- a/tests/cfg/di_scopes_primitives.py
+++ b/tests/cfg/di_scopes_primitives.py
@@ -1,0 +1,95 @@
+from pest.decorators.controller import controller
+from pest.decorators.handler import get
+from pest.decorators.module import module
+from pest.metadata.types.module_meta import ClassProvider, Scope
+
+
+class Scoped:
+    def get_id(self) -> int:
+        return id(self)
+
+
+class Singleton:
+    def get_id(self) -> int:
+        return id(self)
+
+
+class Transient:
+    def get_id(self) -> int:
+        return id(self)
+
+
+class Dependent:
+    scoped_svc: Scoped
+    singleton_svc: Singleton
+    transient_svc: Transient
+
+    def get_scoped_id(self) -> int:
+        return self.scoped_svc.get_id()
+
+    def get_singleton_id(self) -> int:
+        return self.singleton_svc.get_id()
+
+    def get_transient_id(self) -> int:
+        return self.transient_svc.get_id()
+
+
+@controller('/scopes')
+class Controller:
+    # controller to test request-scoped services
+    dependent: Dependent
+    scoped: Scoped
+    singleton: Singleton
+    transient: Transient
+
+    @get('/scoped')
+    def get_id(self) -> list[int]:
+        # they all should have the same id for the same request
+        # but different ids for different requests
+        return [
+            self.dependent.get_scoped_id(),
+            self.scoped.get_id(),
+            id(self.scoped)
+        ]
+
+    @get('/singleton')
+    def get_singleton_id(self) -> list[int]:
+        # they all should have the same id across requests
+        return [
+            self.dependent.get_singleton_id(),
+            self.singleton.get_id(),
+            id(self.singleton)
+        ]
+
+    @get('/transient')
+    def get_transient_id(self) -> list[int]:
+        # they all should have different ids across requests
+        return [
+            self.dependent.get_transient_id(),
+            self.transient.get_id(),
+        ]
+
+
+@module(
+    providers=[
+        ClassProvider(
+            provide=Scoped,
+            use_class=Scoped,
+            scope=Scope.SCOPED
+        ),
+        ClassProvider(
+            provide=Singleton,
+            use_class=Singleton,
+            scope=Scope.SINGLETON
+        ),
+        ClassProvider(
+            provide=Transient,
+            use_class=Transient,
+            scope=Scope.TRANSIENT
+        ),
+        Dependent
+    ],
+    controllers=[Controller]
+)
+class DIScopesModule():
+    pass

--- a/tests/cfg/fixtures.py
+++ b/tests/cfg/fixtures.py
@@ -1,13 +1,18 @@
 from typing import cast
 
 import pytest
+from fastapi import Request, Response
 from fastapi.testclient import TestClient
+from starlette.middleware.base import RequestResponseEndpoint
 
 from pest.core.application import PestApplication
 from pest.core.module import Module
 from pest.core.module import setup_module as _setup_module
+from pest.factory import Pest
+from tests.cfg.di_scopes_primitives import Scoped, Transient
 
 from .app.app import bootstrap_app
+from .di_scopes_primitives import DIScopesModule, Singleton
 from .pest_primitives import (
     Mod,
     ModuleWithController,
@@ -33,5 +38,27 @@ def module_with_controller() -> Module:
 @pytest.fixture()
 def app_n_client() -> tuple[PestApplication, TestClient]:
     app = bootstrap_app()
+    client = TestClient(app)
+    return app, client
+
+
+@pytest.fixture()
+def di_app_n_client() -> tuple[PestApplication, TestClient]:
+    app = Pest.create(root_module=DIScopesModule)
+
+    @app.middleware('http')
+    async def middleware(
+        request: Request,
+        call_next: RequestResponseEndpoint,
+        scoped: Scoped,
+        singleton: Singleton,
+        transient: Transient,
+    ) -> Response:
+        response = await call_next(request)
+        response.headers['Scoped-Id'] = str(scoped.get_id())
+        response.headers['Singleton-Id'] = str(singleton.get_id())
+        response.headers['Transient-Id'] = str(transient.get_id())
+        return response
+
     client = TestClient(app)
     return app, client

--- a/tests/cfg/pest_primitives.py
+++ b/tests/cfg/pest_primitives.py
@@ -1,5 +1,6 @@
 from pest.decorators.controller import controller
 from pest.decorators.module import module
+from pest.metadata.types.module_meta import ClassProvider, Scope
 
 
 class ProviderFoo:
@@ -50,4 +51,17 @@ class FooModule:
     providers=[ProviderFoo, ProviderBar, ProviderBaz],
 )
 class ModuleWithController:
+    pass
+
+
+@module(
+    providers=[
+        ClassProvider(
+            provide=ProviderFoo,
+            use_class=ProviderFoo,
+            scope=Scope.SCOPED
+        )
+    ]
+)
+class ScopeTestModule:
     pass

--- a/tests/test_di.py
+++ b/tests/test_di.py
@@ -1,0 +1,77 @@
+from fastapi.testclient import TestClient
+
+from pest.core.application import PestApplication
+
+
+def test_request_scoped_provider(di_app_n_client: tuple[PestApplication, TestClient]) -> None:
+    """🐀 di :: scoped :: scoped services should act as singletons for the lifetime of a request"""
+    _, client = di_app_n_client
+
+    r1 = client.get('/scopes/scoped')
+    r2 = client.get('/scopes/scoped')
+
+    # ids comming from a user defined header inside a middleware with an
+    # injected scoped service
+    r1_head = int(r1.headers['Scoped-Id'])
+    r2_head = int(r2.headers['Scoped-Id'])
+
+    r1_ids = list(r1.json()) + [r1_head]
+    r2_ids = list(r2.json()) + [r2_head]
+
+    # assert that all ids in r1 are the same
+    assert len(set(r1_ids)) == 1
+    # assert that all ids in r2 are the same
+    assert len(set(r2_ids)) == 1
+
+    # assert that the ids in r1 and r2 are different (different requests)
+    assert r1_head != r2_head
+
+
+def test_singletons_doent_change(di_app_n_client: tuple[PestApplication, TestClient]) -> None:
+    """🐀 di :: singleton ::
+    scoped services should act as singletons for the lifetime of a request
+    """
+    _, client = di_app_n_client
+
+    r1 = client.get('/scopes/singleton')
+    r2 = client.get('/scopes/singleton')
+
+    # ids comming from a user defined header inside a middleware with an
+    # injected scoped service
+    r1_head = int(r1.headers['Singleton-Id'])
+    r2_head = int(r2.headers['Singleton-Id'])
+
+    r1_ids = list(r1.json()) + [r1_head]
+    r2_ids = list(r2.json()) + [r2_head]
+
+    # assert that all ids in r1 are the same
+    assert len(set(r1_ids)) == 1
+    # assert that all ids in r2 are the same
+    assert len(set(r2_ids)) == 1
+
+    # assert that the ids in r1 and r2 are the same across requests
+    assert r1_head == r2_head
+
+
+def test_transient_always_new_instance(di_app_n_client: tuple[PestApplication, TestClient]) -> None:
+    """🐀 di :: transient :: transient services should always return a new instance"""
+    _, client = di_app_n_client
+
+    r1 = client.get('/scopes/transient')
+    r2 = client.get('/scopes/transient')
+
+    # ids comming from a user defined header inside a middleware with an
+    # injected scoped service
+    r1_head = int(r1.headers['Transient-Id'])
+    r2_head = int(r2.headers['Transient-Id'])
+
+    r1_ids = list(r1.json()) + [r1_head]
+    r2_ids = list(r2.json()) + [r2_head]
+
+    # assert that all ids in r1 are the different
+    assert len(set(r1_ids)) == len(r1_ids)
+    # assert that all ids in r2 are the different
+    assert len(set(r2_ids)) == len(r2_ids)
+
+    # assert that the ids in r1 and r2 are different (different requests)
+    assert r1_head != r2_head

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,6 +22,7 @@ def test_colorize_no_color_option():
 
 
 def test_module_tree_generation():
+    """🐀 utils :: module :: should generate a tree representation of a module"""
     module = _setup_module(FooModule)
 
     tree = as_tree(module)


### PR DESCRIPTION
Implements a middleware that injects an `ActivationScope`, which is then used to resolve `SCOPED` dependencies on a per-request basis.

This allows having "pseudo-singletons" that only act as singletons during the lifespan of a single request (same instance for same request, but different instances for different requests)

rel: #5 