### PR TITLE
fix: 🚑 wrong provider instance when resolved from parent

### DIFF
--- a/pest/core/module.py
+++ b/pest/core/module.py
@@ -133,12 +133,18 @@ class Module(PestPrimitive):
         # can have access to services provided by the parent module
         # or globally (in the root module)
         if parent is not None:
-            for provider, _ in contained_in(parent):
 
+            def create_factory(provider: InjectionToken) -> Any:
                 def resolve_from_parent() -> Any:
-                    return parent.get(cast(InjectionToken, provider))
+                    resolved = parent.get(cast(InjectionToken, provider))
+                    return resolved
 
-                self.register(FactoryProvider(provide=provider, use_factory=resolve_from_parent))
+                return resolve_from_parent
+
+            for provider, _ in contained_in(parent):
+                self.register(
+                    FactoryProvider(provide=provider, use_factory=create_factory(provider))
+                )
 
         # setup child modules
         for child in meta.imports if meta.imports else []:

--- a/tests/cfg/fixtures.py
+++ b/tests/cfg/fixtures.py
@@ -16,6 +16,7 @@ from pest.core.module import setup_module as _setup_module
 from pest.factory import Pest
 from tests.cfg.test_modules.di_scopes_primitives import Scoped, Transient
 
+from .test_apps.multi_singleton_app import app as multi_singleton_app
 from .test_apps.todo_app import app as todo_app
 from .test_modules.di_scopes_primitives import DIScopesModule, Singleton
 from .test_modules.fastapi_dependencies import FastApiDependenciesModule
@@ -47,6 +48,13 @@ def module_with_controller() -> Module:
 @pytest.fixture()
 def app_n_client() -> TestApp:
     app = todo_app.bootstrap_app()
+    client = TestClient(app)
+    return app, client
+
+
+@pytest.fixture()
+def multiple_singletons_app() -> TestApp:
+    app = multi_singleton_app.bootstrap_app()
     client = TestClient(app)
     return app, client
 

--- a/tests/cfg/test_apps/multi_singleton_app/app.py
+++ b/tests/cfg/test_apps/multi_singleton_app/app.py
@@ -1,0 +1,10 @@
+from pest.core.application import PestApplication
+from pest.factory import Pest
+
+from .app_module import AppModule
+
+
+def bootstrap_app() -> PestApplication:
+    app = Pest.create(root_module=AppModule)
+
+    return app

--- a/tests/cfg/test_apps/multi_singleton_app/app_module.py
+++ b/tests/cfg/test_apps/multi_singleton_app/app_module.py
@@ -1,0 +1,41 @@
+from pest import controller, get, module
+from pest.metadata.types.injectable_meta import ValueProvider
+
+
+class Repo1:
+    def get(self):
+        return 'this is repo 1'
+
+
+class Repo2:
+    def get(self):
+        return 'this is repo 2'
+
+
+@controller('/ctrl')
+class Controller1:
+    repo1: Repo1
+    repo2: Repo2
+
+    @get('/')
+    def get(self):
+        return {
+            'repo1': id(self.repo1),
+            'repo2': id(self.repo2),
+        }
+
+
+@module(controllers=[Controller1])
+class ChildModule:
+    pass
+
+
+@module(
+    imports=[ChildModule],
+    providers=[
+        ValueProvider(provide=Repo1, use_value=Repo1()),
+        ValueProvider(provide=Repo2, use_value=Repo2()),
+    ],
+)
+class AppModule:
+    pass


### PR DESCRIPTION
ref: #31 