### PR TITLE
feat: ✨ accept a callable as a default value for format

### DIFF
--- a/example/app/main.py
+++ b/example/app/main.py
@@ -60,6 +60,7 @@ app = Pest.create(
     logging={
         'intercept': [('uvicorn*', LogLevel.DEBUG), 'pest*', 'fastapi'],
         'level': LogLevel.DEBUG,
+        'format': format_record,
         'access_log': True,
         'sinks': [{'sink': 'example/logs/app.log', 'rotation': '1 week', 'format': format_record}],
     },

--- a/pest/logging/__init__.py
+++ b/pest/logging/__init__.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
             FormatFunction,
             Message,
             PathLikeStr,
+            Record,
             RetentionFunction,
             RotationFunction,
             Writable,
@@ -81,7 +82,7 @@ class LoggingOptions(TypedDict, total=False):
     '''list of built-in loggers to shush using `loguru`'''
     level: LogLevel
     '''default log level for all loggers'''
-    format: Union[str, None]
+    format: Union[str, Callable[['Record'], str], None]
     '''override default log format'''
     access_log: bool
     '''whether to enable access logging'''


### PR DESCRIPTION
#### Current behavior
Until today, the `format` parameter in the logging configuration of Pest only accepts a `str` as a default value.


#### Proposed enhancement
Make it possible to pass a callable as a default value for format. This would allow for lazy evaluation of the default value, which can be useful in cases when we need, for example, context-dependent formatting for our logs.

```python
def format_record(record: loguru.Record) -> str:
    format_string = '<green>{time}</green> <level>{message}</level>\n'

    # since we have access to the record, we can now conditionally change the format in whatever way we want :)

    return format_string

app = Pest.create(
    AppModule,
    logging={
        'intercept': [('uvicorn*', LogLevel.DEBUG), 'pest*', 'fastapi'],
        'level': LogLevel.DEBUG,
        'format': format_record,
        ...
    },
)
```

Closes: #39