### PR TITLE
feat: ✨ route guards

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,6 +24,17 @@
             "justMyCode": false
         },
         {
+            "name": "FastAPI: Example2",
+            "type": "python",
+            "request": "launch",
+            "module": "uvicorn",
+            "args": [
+                "guard:app",
+                "--reload",
+            ],
+            "justMyCode": false
+        },
+        {
             "name": "FastAPI: Test",
             "type": "python",
             "request": "launch",

--- a/pest/__init__.py
+++ b/pest/__init__.py
@@ -1,4 +1,5 @@
 from .decorators.controller import api, controller, ctrl, router, rtr
+from .decorators.guard import Guard, GuardCb, GuardExtra, use_guard
 from .decorators.handler import delete, get, head, options, patch, post, put, trace
 from .decorators.module import dom, domain, mod, module
 from .factory import Pest
@@ -12,6 +13,8 @@ from .metadata.types.injectable_meta import (
     ValueProvider,
 )
 from .utils.decorators import meta
+
+guard = use_guard
 
 __all__ = [
     'Pest',
@@ -37,6 +40,12 @@ __all__ = [
     'api',
     # decorators - utils
     'meta',
+    # decorators - guard
+    'Guard',
+    'GuardCb',
+    'GuardExtra',
+    'use_guard',
+    'guard',
     # meta - providers
     'ProviderBase',
     'ClassProvider',

--- a/pest/decorators/guard.py
+++ b/pest/decorators/guard.py
@@ -1,0 +1,146 @@
+from functools import wraps
+from inspect import Parameter, getmembers, iscoroutinefunction, isfunction, signature
+from typing import Any, Callable, Dict, List, Optional, Protocol, Tuple, Type, get_args
+
+from fastapi import Request
+
+from ..core.handler import HandlerFn
+from ..exceptions.http.http import ForbiddenException
+from ..metadata.meta import get_meta, get_meta_value
+from ..metadata.types._meta import PestType
+
+GuardCb = Callable[[Dict[str, Any]], None]
+
+
+class Guard(Protocol):
+    """🐀 ⇝ base guard protocol"""
+
+    def can_activate(
+        self, request: Request, *, context: Dict[str, Any], set_result: GuardCb
+    ) -> bool:
+        """🐀 ⇝ determines if the request can be activated by the current request"""
+        ...
+
+
+def use_guard(guard: Type[Guard]) -> Callable:
+    """🐀 ⇝ decorator to apply a guard either to a single method or all methods in a class"""
+
+    def decorator(target: Callable) -> Callable:
+        if isinstance(target, type):  # If it's a class, apply to all methods
+            return _apply_guard_to_class(target, guard)
+        else:
+            return _apply_guard_to_method(target, guard)
+
+    return decorator
+
+
+class GuardExtra(Dict[str, Any]):
+    pass
+
+
+def _extract_params(params: List[Parameter]) -> Tuple[Optional[Parameter], List[Parameter]]:
+    """
+    extracts the request and all parameters annotated with "guard_extra" from a list of parameters
+    """
+    request_param = None
+    extra_params = []
+
+    for param in params:
+        if param.annotation == Request:
+            request_param = param
+        elif param.annotation is GuardExtra:
+            extra_params.append(param)
+        else:
+            anns = get_args(param.annotation)
+            if len(anns) == 0:
+                continue
+
+            typing, metas = anns[0], anns[1:]
+            if typing == GuardExtra or GuardExtra in metas:
+                extra_params.append(param)
+
+    return request_param, extra_params
+
+
+# applies the guard to a single method
+def _apply_guard_to_method(func: Callable, guard: Type[Guard]) -> Callable:
+    sig = signature(func)
+    params: List[Parameter] = list(sig.parameters.values())
+
+    # check if there's any parameter annotated with type Request
+    request_parameter, extras = _extract_params(params)
+    request_was_in_original_sig = request_parameter is not None
+
+    if request_parameter is None:
+        # add the parameter to the signature, annotated with type Request
+        request_param_name = '__request__'
+        params = [
+            *params,
+            Parameter(request_param_name, Parameter.POSITIONAL_OR_KEYWORD, annotation=Request),
+        ]
+    else:
+        request_param_name = request_parameter.name
+
+    # remove the extras the `params` list
+    params = [param for param in params if param not in extras]
+
+    @wraps(func)
+    async def wrapper(*args: Any, **kwargs: Any) -> Any:
+        meta = get_meta(func)
+
+        # try to extract the request object from kwargs or args
+        request = kwargs.get(request_param_name)
+        if request is None:
+            for arg in args:
+                if isinstance(arg, Request):
+                    request = arg
+                    break
+
+        if not request:
+            raise ValueError('Request object not found in args or kwargs')
+
+        extra_result: Dict[str, Any] = {}
+
+        def set_result(result: Dict[str, Any]) -> None:
+            nonlocal extra_result
+            extra_result = result
+
+        # apply the guard
+        guard_instance = guard()
+        if not guard_instance.can_activate(request, context=meta, set_result=set_result):
+            raise ForbiddenException('Not authorized')
+
+        # if the request was not in the original signature, remove it from args/kwargs
+        if not request_was_in_original_sig:
+            kwargs.pop(request_param_name, None)
+            args = tuple([arg for arg in args if not isinstance(arg, Request)])
+
+        # add the extra result to the signature
+        for param in extras:
+            if param.annotation is GuardExtra:
+                kwargs[param.name] = extra_result
+            else:
+                kwargs[param.name] = extra_result.get(param.name, None)
+
+        return await func(*args, **kwargs) if iscoroutinefunction(func) else func(*args, **kwargs)
+
+    # update the signature to include the new 'request' parameter
+    setattr(wrapper, '__signature__', sig.replace(parameters=params))
+    return wrapper
+
+
+# applies the guard to all methods in a class
+def _apply_guard_to_class(cls: type, guard: Type[Guard]) -> type:
+    members = getmembers(cls, lambda m: isfunction(m))
+    handlers: List[HandlerFn] = []
+
+    for _, method in members:
+        meta_type = get_meta_value(method, key='meta_type', type=PestType, default=None)
+        if meta_type == PestType.HANDLER:
+            handlers.append(method)
+
+    for handler in handlers:
+        replacement = _apply_guard_to_method(handler, guard)
+        setattr(cls, handler.__name__, replacement)
+
+    return cls

--- a/pest/utils/decorators.py
+++ b/pest/utils/decorators.py
@@ -5,18 +5,21 @@ from ..metadata.meta import inject_metadata
 from .protocols import DataclassInstance
 
 Cls = TypeVar('Cls', bound=Type[Any])
+Fn = TypeVar('Fn', bound=Callable[..., Any])
 
 
-def meta(meta: Union[Mapping[str, Any], DataclassInstance]) -> Callable[[Cls], Cls]:
+def meta(
+    meta: Union[Mapping[str, Any], DataclassInstance]
+) -> Callable[[Union[Cls, Fn]], Union[Cls, Fn]]:
     """🐀 » injects metadata into a class"""
 
-    def wrapper(cls: Cls) -> Cls:
+    def decorator(callable: Union[Cls, Fn]) -> Union[Cls, Fn]:
         if isinstance(meta, Mapping):
             metadata = meta
         else:
             metadata = asdict(meta)
 
-        inject_metadata(cls, metadata)
-        return cls
+        inject_metadata(callable, metadata)
+        return callable
 
-    return wrapper
+    return decorator

--- a/tests/cfg/fixtures.py
+++ b/tests/cfg/fixtures.py
@@ -16,6 +16,7 @@ from pest.core.module import setup_module as _setup_module
 from pest.factory import Pest
 from tests.cfg.test_modules.di_scopes_primitives import Scoped, Transient
 
+from .test_apps.guards_app import app as guards_app
 from .test_apps.multi_singleton_app import app as multi_singleton_app
 from .test_apps.todo_app import app as todo_app
 from .test_modules.di_scopes_primitives import DIScopesModule, Singleton
@@ -55,6 +56,13 @@ def app_n_client() -> TestApp:
 @pytest.fixture()
 def multiple_singletons_app() -> TestApp:
     app = multi_singleton_app.bootstrap_app()
+    client = TestClient(app)
+    return app, client
+
+
+@pytest.fixture()
+def guards_annotated_app() -> TestApp:
+    app = guards_app.bootstrap_app()
     client = TestClient(app)
     return app, client
 

--- a/tests/cfg/test_apps/guards_app/app.py
+++ b/tests/cfg/test_apps/guards_app/app.py
@@ -1,0 +1,73 @@
+import json
+from base64 import b64decode
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from fastapi import Request
+
+from pest import Guard, GuardCb, GuardExtra, Pest, controller, get, meta, module, use_guard
+from pest.core.application import PestApplication
+from pest.exceptions.http.http import UnauthorizedException
+
+try:
+    from typing import Annotated
+except ImportError:
+    from typing_extensions import Annotated
+
+
+@dataclass
+class User:
+    id: int
+    name: str
+    role: str
+
+
+class AuthGuard(Guard):
+    def can_activate(self, request: Request, *, context: Any, set_result: GuardCb) -> bool:
+        token = request.headers.get('Authorization')
+        roles = context.get('roles', [])
+        if not token:
+            raise UnauthorizedException('Token is required')
+
+        try:
+            decoded_token = b64decode(token).decode()
+            token_data = json.loads(decoded_token)
+            if token_data.get('role') in roles:
+                set_result({'user': User(**token_data)})
+                return True
+            else:
+                return False
+        except Exception:
+            return False
+
+
+def roles(*role_list: str) -> Callable:
+    def wrapper(fn: Callable) -> Callable:
+        return meta({'roles': list(role_list)})(fn)
+
+    return wrapper
+
+
+@controller('/secure')
+@use_guard(AuthGuard)
+class Controller:
+    @get('/')
+    @roles('admin', 'superuser')
+    def annotated(self, user: Annotated[User, GuardExtra]) -> dict:
+        return {'message': "You're allowed to see this because your role is " + user.role}
+
+    @get('/typed')
+    @roles('admin', 'superuser')
+    def get_typed(self, guard_result: GuardExtra) -> dict:
+        user: User = guard_result['user']
+        return {'message': "You're allowed to see this because your role is " + user.role}
+
+
+@module(controllers=[Controller])
+class AppModule:
+    pass
+
+
+def bootstrap_app() -> PestApplication:
+    app = Pest.create(root_module=AppModule)
+    return app

--- a/tests/test_guard.py
+++ b/tests/test_guard.py
@@ -1,0 +1,47 @@
+import sys
+from base64 import b64encode
+
+import pytest
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(sys.version_info < (3, 9), reason='requires python3.9 or higher')
+async def test_guards_annotated(guards_annotated_app) -> None:
+    """🐀 guard :: annotated :: should run guards to decide if can activate route (>=3.9)"""
+
+    _, client = guards_annotated_app
+
+    admin_token = b64encode('{"id": 1, "name": "John Doe", "role": "admin"}'.encode()).decode()
+    user_token = b64encode('{"id": 1, "name": "Jane Doe", "role": "user"}'.encode()).decode()
+
+    ok = client.get('/secure', headers={'Authorization': admin_token}).json()
+    assert ok == {'message': "You're allowed to see this because your role is admin"}
+
+    forb = client.get('/secure', headers={'Authorization': user_token})
+    assert forb.status_code == 403
+    assert forb.json() == {'code': 403, 'error': 'Forbidden', 'message': 'Not authorized'}
+
+    unauth = client.get('/secure')
+    assert unauth.status_code == 401
+    assert unauth.json() == {'code': 401, 'error': 'Unauthorized', 'message': 'Token is required'}
+
+
+@pytest.mark.asyncio
+async def test_guards_typed(guards_annotated_app) -> None:
+    """🐀 guard :: typed :: should run guards to decide if can activate route (>=3.8)"""
+
+    _, client = guards_annotated_app
+
+    admin_token = b64encode('{"id": 1, "name": "John Doe", "role": "admin"}'.encode()).decode()
+    user_token = b64encode('{"id": 1, "name": "Jane Doe", "role": "user"}'.encode()).decode()
+
+    ok = client.get('/secure/typed', headers={'Authorization': admin_token}).json()
+    assert ok == {'message': "You're allowed to see this because your role is admin"}
+
+    forb = client.get('/secure/typed', headers={'Authorization': user_token})
+    assert forb.status_code == 403
+    assert forb.json() == {'code': 403, 'error': 'Forbidden', 'message': 'Not authorized'}
+
+    unauth = client.get('/secure/typed')
+    assert unauth.status_code == 401
+    assert unauth.json() == {'code': 401, 'error': 'Unauthorized', 'message': 'Token is required'}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -99,6 +99,10 @@ def test_meta_docorator_dataclass_meta():
 
 
 def test_exception_example_generator():
+    """
+    🐀 utils :: `exc_response` :: should generate the right example response for a given error code
+    """
+
     example = exc_response(404, 418)
 
     not_found = example[404]


### PR DESCRIPTION
Alternate solution to #10 that doesn't require an implementation of route-controller level middlewares.

This implementation doesn't use starlette middlewares, but... it works. 

- **Implements controller/route level route guards.**

```py
class AuthGuard(Guard):
    def can_activate(self, request: Request, *, context: Any, set_result: GuardCb) -> bool:
        # guard logic
```

- **Per-Controller guards.**

```py
@controller('/secure')
@use_guard(AuthGuard)
class Controller:
    ...
```

- **Per-Route Controller.**

```py
@controller('/secure')
class Controller:
    @get('/')
    @use_guard(AuthGuard)
    def annotated(self, user: Annotated[User, GuardExtra]) -> dict:
        ...
```

> [!Note]
> Doesn't implement application-level route guards; it would be more efficient
> to implement this when we have controller/route-level middlewares (see #6)
> 
> Although not ideal, this is a temp solution