### PR TITLE
fix: 🚑 use_guard fails with non-default argument follows default argumen

### DIFF
--- a/pest/decorators/guard.py
+++ b/pest/decorators/guard.py
@@ -109,7 +109,12 @@ def _apply_guard_to_method(
         request_param_name = '__pest_guard_request__'
         params = [
             *params,
-            Parameter(request_param_name, Parameter.POSITIONAL_OR_KEYWORD, annotation=Request),
+            Parameter(
+                request_param_name,
+                Parameter.POSITIONAL_OR_KEYWORD,
+                annotation=Request,
+                default=Request({'type': 'http'}),
+            ),
         ]
     else:
         request_param_name = request_parameter.name


### PR DESCRIPTION
### Fixes the following error:

Using `use_guard` in a route with a default value fails:

```py
@controller('/endpoint')
@use_guard(MyGuard)
class Controller:
    @get('/')
    async def my_route(self, svc: Service = inject(yield_service)):
        ...
```

Fails with:

`ValueError: non-default argument follows default argument`