### PR TITLE
fix: 🚑 loguru logs always colorized

### DIFF
--- a/examples/api/app/main.py
+++ b/examples/api/app/main.py
@@ -62,7 +62,7 @@ app = Pest.create(
         'level': LogLevel.DEBUG,
         # 'format': format_record,
         'access_log': True,
-        'sinks': [{'sink': 'example/logs/app.log', 'rotation': '1 week', 'format': format_record}],
+        'sinks': [{'sink': 'examples/logs/app.log', 'rotation': '1 week', 'format': format_record}],
     },
     middleware=[Middleware(PureAsgiMiddleware), pest_middleware],
     cors={

--- a/pest/logging/__init__.py
+++ b/pest/logging/__init__.py
@@ -89,3 +89,12 @@ class LoggingOptions(TypedDict, total=False):
     verbose: bool
     '''enables all loggers'''
     sinks: List[SinkOptions]
+    '''list of sinks (handlers) to be used by loguru'''
+    force_colorize: bool
+    '''forces colorized output for the default sink'''
+    diagnose: bool
+    '''
+    Whether the exception trace should display the variables values to eases the debugging.
+    `False` (the default) is recommended for production environments, to avoid leaking sensitive
+    data..
+    '''

--- a/pest/logging/loguru/loguru.py
+++ b/pest/logging/loguru/loguru.py
@@ -101,6 +101,8 @@ class Loguru:
         access_log = options.get('access_log', False)
         verbose = options.get('verbose', False)
         sinks = options.get('sinks', [])
+        colorize = options.get('force_colorize', None)
+        diagnose = options.get('diagnose', False)
 
         # if a format string is provided, we replace the default
         if type(fmt) is str:
@@ -108,7 +110,7 @@ class Loguru:
 
         cls.__config_standard_interception(intercept, verbose)
         cls.__configure_shush(shush)
-        cls.__config_sinks(sinks, level, access_log, fmt)
+        cls.__config_sinks(sinks, level, access_log, fmt, colorize, diagnose)
 
     @classmethod
     def __config_standard_interception(
@@ -171,6 +173,8 @@ class Loguru:
         level: LogLevel,
         access_log: bool,
         fmt: Union[str, Callable[[loguru.Record], str], None],
+        colorize: bool | None = None,
+        diagnose: bool = False,
     ) -> None:
         """configures loguru sinks (handlers)"""
         fmt_func = fmt if callable(fmt) else format_record
@@ -178,8 +182,8 @@ class Loguru:
         loguru_logger.configure(handlers=[])
         loguru_logger.add(
             sys.stdout,
-            colorize=True,
-            diagnose=False,
+            colorize=colorize,
+            diagnose=diagnose,
             format=fmt_func,
             level=level,
             filter=lambda record: ((True if access_log else no_access(record))),


### PR DESCRIPTION
+ new param "force_colorize" defaulted to None instead of
  having it obscured and always to True