### PR TITLE
feat: ✨ introduce lifecycle hooks

### DIFF
--- a/pest/__init__.py
+++ b/pest/__init__.py
@@ -1,3 +1,4 @@
+from .core.common import OnApplicationBootstrap, OnModuleInit
 from .decorators.controller import api, controller, ctrl, router, rtr
 from .decorators.guard import Guard, GuardCb, GuardCtx, GuardExtra, use_guard
 from .decorators.handler import delete, get, head, options, patch, post, put, trace
@@ -9,7 +10,6 @@ from .metadata.types.injectable_meta import (
     FactoryProvider,
     ProviderBase,
     Scope,
-    SingletonProvider,
     ValueProvider,
 )
 from .utils.decorators import meta
@@ -51,8 +51,10 @@ __all__ = [
     'ProviderBase',
     'ClassProvider',
     'ValueProvider',
-    'SingletonProvider',
     'FactoryProvider',
     'ExistingProvider',
     'Scope',
+    # lifecycle hook protocols
+    'OnModuleInit',
+    'OnApplicationBootstrap',
 ]

--- a/pest/core/common/__init__.py
+++ b/pest/core/common/__init__.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from inspect import isclass
-from typing import Union
+from typing import Any, Coroutine, Protocol, Union, runtime_checkable
 
 from ...utils.functions import classproperty
 
@@ -23,6 +23,40 @@ class PestPrimitive(ABC):
     def __pest_object_type__(cls) -> PestType:
         """🐀 ⇝ returns the type of pest object"""
         ...
+
+
+@runtime_checkable
+class OnModuleInit(Protocol):
+    """🐀 ⇝ on module init protocol
+
+    Protocol defining an `on_module_init` method that is called once the host module's dependencies
+    have been resolved
+    """
+
+    def on_module_init(self) -> Union[None, Coroutine[Any, Any, None]]:
+        """🐀 ⇝ on module init
+
+        called during the initialization of the module, once the host module's dependencies have
+        been resolved
+        """
+        pass
+
+
+@runtime_checkable
+class OnApplicationBootstrap(Protocol):
+    """🐀 ⇝ on application bootstrap protocol
+
+    Protocol defining an `on_application_bootstrap` method that is called during the application's
+    bootstrap phase, once all modules have been initialized, but before listening for connections.
+    """
+
+    def on_application_bootstrap(self) -> Union[None, Coroutine[Any, Any, None]]:
+        """🐀 ⇝ on application bootstrap
+
+        called during the application's bootstrap phase, once all modules have been initialized,
+        but before listening for connections.
+        """
+        pass
 
 
 def is_primitive(clazz: Union[type, object]) -> TypeGuard[PestPrimitive]:

--- a/pest/core/controller.py
+++ b/pest/core/controller.py
@@ -10,7 +10,7 @@ from ..metadata.types.controller_meta import ControllerMeta
 from ..metadata.types.handler_meta import HandlerMeta
 from ..utils.fastapi.router import PestRouter
 from ..utils.functions import classproperty
-from .common import PestPrimitive
+from .common import OnApplicationBootstrap, OnModuleInit, PestPrimitive
 from .handler import HandlerTuple, setup_handler
 from .types.status import Status
 
@@ -56,7 +56,7 @@ def module_of(cls: type) -> 'Module':
     return mod
 
 
-class Controller(PestPrimitive):
+class Controller(PestPrimitive, OnModuleInit, OnApplicationBootstrap):
     __router__: ClassVar[PestRouter]
     __parent_module__: ClassVar[Optional[Any]]
 

--- a/pest/core/module.py
+++ b/pest/core/module.py
@@ -133,6 +133,9 @@ async def _on_application_bootstrap(module: 'Module') -> None:
     if module.__class_status__ != Status.READY:
         return
 
+    for child in module.imports:
+        await _on_application_bootstrap(child)
+
     for provider in module.providers:
         # if the provider's scope is singleton/value, we check if the provider has lifecycle
         # hooks and call them if that's the case
@@ -148,9 +151,6 @@ async def _on_application_bootstrap(module: 'Module') -> None:
         resolved = await maybe_coro(module.aget(cast(Type[Controller], controller)))
         if isinstance(resolved, OnApplicationBootstrap):
             await maybe_coro(resolved.on_application_bootstrap())
-
-    for child in module.imports:
-        await _on_application_bootstrap(child)
 
     # and finally, ourselves
     await maybe_coro(module.on_application_bootstrap())

--- a/pest/core/types/fastapi_params.py
+++ b/pest/core/types/fastapi_params.py
@@ -1,4 +1,5 @@
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Coroutine,
@@ -10,11 +11,13 @@ from typing import (
     Union,
 )
 
-from fastapi import FastAPI, Request, Response
+from fastapi import Request, Response
 from fastapi.params import Depends
 from fastapi.routing import APIRouter
 from starlette.routing import BaseRoute
-from starlette.types import Lifespan
+
+if TYPE_CHECKING:
+    pass
 
 
 class FastAPIParams(TypedDict, total=False):
@@ -40,7 +43,6 @@ class FastAPIParams(TypedDict, total=False):
     ]
     on_startup: Sequence[Callable[[], Any]]
     on_shutdown: Sequence[Callable[[], Any]]
-    lifespan: Lifespan[FastAPI]
     terms_of_service: str
     contact: Dict[str, Union[str, Any]]
     license_info: Dict[str, Union[str, Any]]

--- a/pest/factory/__init__.py
+++ b/pest/factory/__init__.py
@@ -5,6 +5,8 @@ except ImportError:
 
 from typing import Union
 
+from starlette.types import Lifespan
+
 from ..core.application import PestApplication
 from ..core.types.fastapi_params import FastAPIParams
 from ..logging import LoggingOptions, log
@@ -26,6 +28,7 @@ class Pest:
         middleware: MiddlewareDef = [],
         prefix: str = '',
         cors: Union[CorsOptions, None] = None,
+        lifespan: Union[Lifespan[PestApplication], None] = None,
         **fastapi_params: Unpack[FastAPIParams],
     ) -> PestApplication:
         """
@@ -41,8 +44,8 @@ class Pest:
         pre_app.setup(logging=logging)
         log.info(f'Initializing {name}')
 
-        app = make_app(fastapi_params, root_module, prefix=prefix, middleware=middleware)
+        app = make_app(
+            fastapi_params, root_module, lifespan=lifespan, prefix=prefix, middleware=middleware
+        )
         app = post_app.setup(app, cors=cors)
-
-        log.debug(f'{name} initialized: \n{app}')
         return app

--- a/pest/factory/app_creator.py
+++ b/pest/factory/app_creator.py
@@ -1,38 +1,75 @@
-from typing import List, cast
+from contextlib import asynccontextmanager
+from typing import AsyncIterator, List, Optional, Union, cast
 
 from fastapi.routing import APIRoute
+from starlette.types import Lifespan
 
 from pest.logging import log
 
 from ..core.application import PestApplication
-from ..core.module import setup_module
+from ..core.module import _on_application_bootstrap, setup_module
 from ..core.types.fastapi_params import FastAPIParams
 from ..metadata.meta import get_meta_value
-from ..middleware.types import MiddlewareDef
+from ..middleware.types import CorsOptions, MiddlewareDef
+from ..utils.functions import chain_lifespan
+from . import openapi
+
+
+def app_lifespan(
+    root_module: type,
+    prefix: str,
+    cors: Union[CorsOptions, None] = None,
+) -> Lifespan['PestApplication']:
+    @asynccontextmanager
+    async def main_lifespan(app: PestApplication) -> AsyncIterator[None]:
+        """main lifespan function
+
+        creates the module tree, appends routes to app and triggers the `on_application_bootstrap`
+        lifecycle hooks
+        """
+
+        module_tree = await setup_module(root_module)
+        app.__pest_module__ = module_tree
+        routers = module_tree.routers
+
+        for router in routers:
+            # log routes while we add em
+            log.info(f'Setting up {get_meta_value(router, "name")}')
+            for route in cast(List[APIRoute], router.routes):
+                for method in route.methods:
+                    full_route = f'{prefix}{route.path}'
+
+                    if full_route == '/' or not full_route.endswith('/'):
+                        log.debug(f'{method: <7} {full_route}')
+
+            # add the router
+            app.include_router(router, prefix=prefix)
+
+        # recreate the openapi schema to include the new routes and customizations
+        openapi.patch(app)
+
+        log.debug(f'{app.title} initialized: \n{app}')
+
+        # trigger the on_application_bootstrap lifecycle hooks on the module tree
+        await _on_application_bootstrap(module_tree)
+
+        yield
+
+    return main_lifespan
 
 
 def make_app(
     fastapi_params: FastAPIParams,
     root_module: type,
+    lifespan: Optional[Lifespan['PestApplication']] = None,
     middleware: MiddlewareDef = [],
+    cors: Union[CorsOptions, None] = None,
     prefix: str = '',
 ) -> PestApplication:
     """Creates the pest application instance"""
-    module_tree = setup_module(root_module)
-    routers = module_tree.routers
-    app = PestApplication(module=module_tree, middleware=middleware, **fastapi_params)
-
-    for router in routers:
-        # log routes while we add em
-        log.info(f'Setting up {get_meta_value(router, "name")}')
-        for route in cast(List[APIRoute], router.routes):
-            for method in route.methods:
-                full_route = f'{prefix}{route.path}'
-
-                if full_route == '/' or not full_route.endswith('/'):
-                    log.debug(f'{method: <7} {full_route}')
-
-        # add the router
-        app.include_router(router, prefix=prefix)
-
-    return app
+    main_lifespan = app_lifespan(root_module, prefix, cors)
+    return PestApplication(
+        middleware=middleware,
+        lifespan=chain_lifespan(main_lifespan, lifespan) if lifespan else main_lifespan,
+        **fastapi_params,
+    )

--- a/pest/factory/openapi.py
+++ b/pest/factory/openapi.py
@@ -1,0 +1,50 @@
+from ..core.application import PestApplication
+from ..exceptions.http.http import ExceptionResponse
+from ..utils.functions import model_schema
+
+
+def patch(app: PestApplication) -> None:
+    """Patches the OpenAPI schema"""
+    openapi_schema = app.openapi()
+    if not openapi_schema:
+        return
+
+    for path in openapi_schema['paths']:
+        for method in openapi_schema['paths'][path]:
+            if openapi_schema['paths'][path][method]['responses'].get('422'):
+                openapi_schema['paths'][path][method]['responses']['400'] = openapi_schema['paths'][
+                    path
+                ][method]['responses']['422']
+
+                # change schema ref to ErrorReponse instead of HTTPValidationError
+                openapi_schema['paths'][path][method]['responses']['400']['content'][
+                    'application/json'
+                ]['schema']['$ref'] = '#/components/schemas/ExceptionResponse'
+
+                # set example
+                openapi_schema['paths'][path][method]['responses']['400']['content'][
+                    'application/json'
+                ]['example'] = {
+                    'code': 400,
+                    'error': 'Bad Request',
+                    'message': [
+                        'error hint',
+                    ],
+                }
+
+                # remove 422
+                openapi_schema['paths'][path][method]['responses'].pop('422')
+
+        components = openapi_schema.get('components')
+        if components:
+            # remove ValidationError and HTTPValidationError
+            schemas = components.get('schemas')
+            if schemas:
+                if schemas.get('ValidationError'):
+                    schemas.pop('ValidationError')
+                if schemas.get('HTTPValidationError'):
+                    schemas.pop('HTTPValidationError')
+                if not schemas.get('ExceptionResponse'):
+                    schemas['ExceptionResponse'] = model_schema(ExceptionResponse)
+
+        app.openapi_schema = openapi_schema

--- a/pest/factory/post_app.py
+++ b/pest/factory/post_app.py
@@ -1,15 +1,12 @@
 from typing import Union
 
 from ..core.application import PestApplication
-from ..exceptions.http.http import ExceptionResponse
 from ..middleware.types import CorsOptions
-from ..utils.functions import model_schema
 
 
 def setup(app: PestApplication, cors: Union[CorsOptions, None] = None) -> PestApplication:
     """Initializes stuff that needs the app to already exist to be able to setup"""
     __setup_cors(app, cors)
-    __patch_open_api(app)
 
     return app
 
@@ -20,50 +17,3 @@ def __setup_cors(app: PestApplication, cors: Union[CorsOptions, None]) -> None:
         return
 
     app.enable_cors(**cors)
-
-
-def __patch_open_api(app: PestApplication) -> None:
-    """Patches the OpenAPI schema"""
-    openapi_schema = app.openapi()
-    if not openapi_schema:
-        return
-
-    for path in openapi_schema['paths']:
-        for method in openapi_schema['paths'][path]:
-            if openapi_schema['paths'][path][method]['responses'].get('422'):
-                openapi_schema['paths'][path][method]['responses']['400'] = openapi_schema['paths'][
-                    path
-                ][method]['responses']['422']
-
-                # change schema ref to ErrorReponse instead of HTTPValidationError
-                openapi_schema['paths'][path][method]['responses']['400']['content'][
-                    'application/json'
-                ]['schema']['$ref'] = '#/components/schemas/ExceptionResponse'
-
-                # set example
-                openapi_schema['paths'][path][method]['responses']['400']['content'][
-                    'application/json'
-                ]['example'] = {
-                    'code': 400,
-                    'error': 'Bad Request',
-                    'message': [
-                        'error hint',
-                    ],
-                }
-
-                # remove 422
-                openapi_schema['paths'][path][method]['responses'].pop('422')
-
-        components = openapi_schema.get('components')
-        if components:
-            # remove ValidationError and HTTPValidationError
-            schemas = components.get('schemas')
-            if schemas:
-                if schemas.get('ValidationError'):
-                    schemas.pop('ValidationError')
-                if schemas.get('HTTPValidationError'):
-                    schemas.pop('HTTPValidationError')
-                if not schemas.get('ExceptionResponse'):
-                    schemas['ExceptionResponse'] = model_schema(ExceptionResponse)
-
-        app.openapi_schema = openapi_schema

--- a/pest/metadata/types/injectable_meta.py
+++ b/pest/metadata/types/injectable_meta.py
@@ -51,13 +51,6 @@ class ValueProvider(ProviderBase, Generic[T]):
 
 
 @dataclass
-class SingletonProvider(ValueProvider, Generic[T]):
-    """🐀 ⇝ defines a `singleton` (value) type provider"""
-
-    pass
-
-
-@dataclass
 class FactoryProvider(ProviderBase, Generic[T]):
     """🐀 ⇝ defines a `factory` type provider"""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,9 @@ ruff = "^0.9.6"
 [tool.poetry.requires-plugins]
 poetry-plugin-export = ">=1.8"
 
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/tests/cfg/fixtures.py
+++ b/tests/cfg/fixtures.py
@@ -32,39 +32,39 @@ TestApp: TypeAlias = Tuple[PestApplication, TestClient]
 
 
 @pytest.fixture()
-def mod() -> Mod:
-    return cast(Mod, _setup_module(Mod))
+async def mod() -> Mod:
+    return cast(Mod, await _setup_module(Mod))
 
 
 @pytest.fixture()
-def parent_mod() -> Module:
-    return _setup_module(ParentMod)
+async def parent_mod() -> Module:
+    return await _setup_module(ParentMod)
 
 
 @pytest.fixture()
-def module_with_controller() -> Module:
-    return _setup_module(ModuleWithController)
+async def module_with_controller() -> Module:
+    return await _setup_module(ModuleWithController)
 
 
 @pytest.fixture()
 def app_n_client() -> TestApp:
     app = todo_app.bootstrap_app()
-    client = TestClient(app)
-    return app, client
+    with TestClient(app) as client:
+        return app, client
 
 
 @pytest.fixture()
 def multiple_singletons_app() -> TestApp:
     app = multi_singleton_app.bootstrap_app()
-    client = TestClient(app)
-    return app, client
+    with TestClient(app) as client:
+        return app, client
 
 
 @pytest.fixture()
 def guards_annotated_app() -> TestApp:
     app = guards_app.bootstrap_app()
-    client = TestClient(app)
-    return app, client
+    with TestClient(app) as client:
+        return app, client
 
 
 @pytest.fixture()
@@ -85,21 +85,20 @@ def di_app_n_client() -> TestApp:
         response.headers['Transient-Id'] = str(transient.get_id())
         return response
 
-    client = TestClient(app)
-    return app, client
+    with TestClient(app) as client:
+        return app, client
 
 
 @pytest.fixture()
 def fastapi_params_app() -> TestApp:
     app = Pest.create(root_module=FastApiParamsModule)
-    client = TestClient(app)
-
-    return app, client
+    with TestClient(app) as client:
+        return app, client
 
 
 @pytest.fixture()
 def fastapi_dependencies_app() -> TestApp:
     app = Pest.create(root_module=FastApiDependenciesModule)
-    client = TestClient(app)
 
-    return app, client
+    with TestClient(app) as client:
+        return app, client

--- a/tests/cfg/test_apps/guards_app/app.py
+++ b/tests/cfg/test_apps/guards_app/app.py
@@ -122,6 +122,11 @@ class ProtectedController:
         user: User = guard_result['user']
         return {'message': f'Hello {user.role} {user.name}'}
 
+    @get('/sudo')
+    @roles('superuser')
+    def sudo(self, user: Annotated[User, GuardExtra]) -> dict:
+        return {'message': f'Hello {user.role} {user.name}'}
+
 
 @module(controllers=[AuthController, ProtectedController])
 class AppModule:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -98,17 +98,16 @@ def test_pest_functional_middleware_cb() -> None:
         return response
 
     app = Pest.create(AppModule, middleware=[pest_middleware])
-    client = TestClient(app)
+    with TestClient(app) as client:
+        response = client.get('/todo')
+        assert 'X-Process-Time' in response.headers
+        time_1 = response.headers['X-Process-Time']
 
-    response = client.get('/todo')
-    assert 'X-Process-Time' in response.headers
-    time_1 = response.headers['X-Process-Time']
+        response = client.get('/todo')
+        assert 'X-Process-Time' in response.headers
+        time_2 = response.headers['X-Process-Time']
 
-    response = client.get('/todo')
-    assert 'X-Process-Time' in response.headers
-    time_2 = response.headers['X-Process-Time']
-
-    assert time_1 != time_2
+        assert time_1 != time_2
 
 
 def test_pest_functional_middleware_cb_with_di():
@@ -127,17 +126,17 @@ def test_pest_functional_middleware_cb_with_di():
         return response
 
     app = Pest.create(AppModule, middleware=[pest_middleware])
-    client = TestClient(app)
 
-    response = client.get('/todo')
-    assert 'X-Request-Id' in response.headers
-    id_1 = response.headers['X-Request-Id']
+    with TestClient(app) as client:
+        response = client.get('/todo')
+        assert 'X-Request-Id' in response.headers
+        id_1 = response.headers['X-Request-Id']
 
-    response = client.get('/todo')
-    assert 'X-Request-Id' in response.headers
-    id_2 = response.headers['X-Request-Id']
+        response = client.get('/todo')
+        assert 'X-Request-Id' in response.headers
+        id_2 = response.headers['X-Request-Id']
 
-    assert id_1 != id_2
+        assert id_1 != id_2
 
 
 def test_pest_class_based_middleware_cb() -> None:
@@ -150,17 +149,16 @@ def test_pest_class_based_middleware_cb() -> None:
             return response
 
     app = Pest.create(AppModule, middleware=[MiddlewareCallback])
-    client = TestClient(app)
+    with TestClient(app) as client:
+        response = client.get('/todo')
+        assert 'X-Process-Time' in response.headers
+        time_1 = response.headers['X-Process-Time']
 
-    response = client.get('/todo')
-    assert 'X-Process-Time' in response.headers
-    time_1 = response.headers['X-Process-Time']
+        response = client.get('/todo')
+        assert 'X-Process-Time' in response.headers
+        time_2 = response.headers['X-Process-Time']
 
-    response = client.get('/todo')
-    assert 'X-Process-Time' in response.headers
-    time_2 = response.headers['X-Process-Time']
-
-    assert time_1 != time_2
+        assert time_1 != time_2
 
 
 def test_pest_class_based_middleware_with_di() -> None:
@@ -175,17 +173,16 @@ def test_pest_class_based_middleware_with_di() -> None:
             return response
 
     app = Pest.create(AppModule, middleware=[MiddlewareCallback])
-    client = TestClient(app)
+    with TestClient(app) as client:
+        response = client.get('/todo')
+        assert 'X-Request-Id' in response.headers
+        id_1 = response.headers['X-Request-Id']
 
-    response = client.get('/todo')
-    assert 'X-Request-Id' in response.headers
-    id_1 = response.headers['X-Request-Id']
+        response = client.get('/todo')
+        assert 'X-Request-Id' in response.headers
+        id_2 = response.headers['X-Request-Id']
 
-    response = client.get('/todo')
-    assert 'X-Request-Id' in response.headers
-    id_2 = response.headers['X-Request-Id']
-
-    assert id_1 != id_2
+        assert id_1 != id_2
 
 
 def test_pest_class_middleware() -> None:
@@ -200,17 +197,16 @@ def test_pest_class_middleware() -> None:
     assert issubclass(Middlware, PestMiddleware)
 
     app = Pest.create(AppModule, middleware=[Middlware])
-    client = TestClient(app)
+    with TestClient(app) as client:
+        response = client.get('/todo')
+        assert 'X-Process-Time' in response.headers
+        time_1 = response.headers['X-Process-Time']
 
-    response = client.get('/todo')
-    assert 'X-Process-Time' in response.headers
-    time_1 = response.headers['X-Process-Time']
+        response = client.get('/todo')
+        assert 'X-Process-Time' in response.headers
+        time_2 = response.headers['X-Process-Time']
 
-    response = client.get('/todo')
-    assert 'X-Process-Time' in response.headers
-    time_2 = response.headers['X-Process-Time']
-
-    assert time_1 != time_2
+        assert time_1 != time_2
 
 
 def test_pest_class_middleware_with_di() -> None:
@@ -229,17 +225,16 @@ def test_pest_class_middleware_with_di() -> None:
     assert issubclass(Middlware, PestMiddleware)
 
     app = Pest.create(AppModule, middleware=[Middlware])
-    client = TestClient(app)
+    with TestClient(app) as client:
+        response = client.get('/todo')
+        assert 'X-Request-Id' in response.headers
+        id_1 = response.headers['X-Request-Id']
 
-    response = client.get('/todo')
-    assert 'X-Request-Id' in response.headers
-    id_1 = response.headers['X-Request-Id']
+        response = client.get('/todo')
+        assert 'X-Request-Id' in response.headers
+        id_2 = response.headers['X-Request-Id']
 
-    response = client.get('/todo')
-    assert 'X-Request-Id' in response.headers
-    id_2 = response.headers['X-Request-Id']
-
-    assert id_1 != id_2
+        assert id_1 != id_2
 
 
 def test_app_params_path_as_var(fastapi_params_app):

--- a/tests/test_exception_handler.py
+++ b/tests/test_exception_handler.py
@@ -28,8 +28,8 @@ class AppModule:
 @pytest.fixture()
 def app() -> Tuple[PestApplication, TestClient]:
     app = Pest.create(root_module=AppModule)
-    client = TestClient(app)
-    return app, client
+    with TestClient(app) as client:
+        return app, client
 
 
 def test_request_scoped_provider(app: Tuple[PestApplication, TestClient]) -> None:

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -126,41 +126,41 @@ def test_trace_handler():
 def test_handler_exludes_nones_by_default() -> None:
     """🐀 handlers :: pydantic :: should exclude None values from handler responses by default"""
     app = Pest.create(PydanticResponsesTestModule)
-    client = TestClient(app)
 
-    response = client.get('/pydantic')
-    json = response.json()
+    with TestClient(app) as client:
+        response = client.get('/pydantic')
+        json = response.json()
 
-    assert response.status_code == 200
-    assert 'surname' not in json
+        assert response.status_code == 200
+        assert 'surname' not in json
 
-    response = client.get('/pydantic-with-nones')
-    json = response.json()
+        response = client.get('/pydantic-with-nones')
+        json = response.json()
 
-    assert response.status_code == 200
-    assert 'surname' in json
-    assert json['surname'] is None
+        assert response.status_code == 200
+        assert 'surname' in json
+        assert json['surname'] is None
 
 
 def test_handler_can_inject_di() -> None:
     """🐀 handlers :: di :: should be able to be injected by rodi"""
     app = Pest.create(RodiDependenciesModule)
-    client = TestClient(app)
 
-    response = client.get('/assigned')
-    assert response.status_code == 200
-    assert isinstance(response.json().get('id'), str)
-    assert len(response.json().get('id')) > 0
+    with TestClient(app) as client:
+        response = client.get('/assigned')
+        assert response.status_code == 200
+        assert isinstance(response.json().get('id'), str)
+        assert len(response.json().get('id')) > 0
 
-    response = client.get('/assigned-no-token')
-    assert response.status_code == 200
-    assert isinstance(response.json().get('id'), str)
-    assert len(response.json().get('id')) > 0
+        response = client.get('/assigned-no-token')
+        assert response.status_code == 200
+        assert isinstance(response.json().get('id'), str)
+        assert len(response.json().get('id')) > 0
 
-    response = client.get('/noinject')
-    assert response.status_code == 200
-    assert isinstance(response.json().get('id'), str)
-    assert len(response.json().get('id')) > 0
+        response = client.get('/noinject')
+        assert response.status_code == 200
+        assert isinstance(response.json().get('id'), str)
+        assert len(response.json().get('id')) > 0
 
 
 @pytest.mark.skipif(sys.version_info < (3, 9), reason='requires python3.9 or higher')
@@ -168,41 +168,39 @@ def test_handlder_can_inject_di_annotation() -> None:
     """🐀 handlers :: di :: should be able to be injected by rodi using Annotation"""
 
     app = Pest.create(RodiDependenciesModule39plus)
-    client = TestClient(app)
-
-    response = client.get('/annotated')
-    assert response.status_code == 200
-    assert isinstance(response.json().get('id'), str)
-    assert len(response.json().get('id')) > 0
+    with TestClient(app) as client:
+        response = client.get('/annotated')
+        assert response.status_code == 200
+        assert isinstance(response.json().get('id'), str)
+        assert len(response.json().get('id')) > 0
 
 
 def test_handler_can_inject_functional_deps() -> None:
     """🐀 handlers :: di :: should be able to have functions and generators as dependencies"""
     app = Pest.create(FunctionsDependenciesModule)
-    client = TestClient(app)
+    with TestClient(app) as client:
+        response = client.get('/assigned')
+        assert response.status_code == 200
+        assert isinstance(response.json().get('id'), str)
+        assert len(response.json().get('id')) > 0
 
-    response = client.get('/assigned')
-    assert response.status_code == 200
-    assert isinstance(response.json().get('id'), str)
-    assert len(response.json().get('id')) > 0
+        # function dependencies should also be able to get query params
+        response = client.get('/assigned?user=foo')
+        assert response.status_code == 200
+        assert isinstance(response.json().get('id'), str)
+        assert response.json().get('id') == 'foo'
 
-    # function dependencies should also be able to get query params
-    response = client.get('/assigned?user=foo')
-    assert response.status_code == 200
-    assert isinstance(response.json().get('id'), str)
-    assert response.json().get('id') == 'foo'
+        # should also work with generators
+        response = client.get('/assigned-with-yield')
+        assert response.status_code == 200
+        assert isinstance(response.json().get('id'), str)
+        assert len(response.json().get('id')) > 0
 
-    # should also work with generators
-    response = client.get('/assigned-with-yield')
-    assert response.status_code == 200
-    assert isinstance(response.json().get('id'), str)
-    assert len(response.json().get('id')) > 0
-
-    # generator function dependencies should also be able to get query params
-    response = client.get('/assigned-with-yield?user=foo')
-    assert response.status_code == 200
-    assert isinstance(response.json().get('id'), str)
-    assert response.json().get('id') == 'foo'
+        # generator function dependencies should also be able to get query params
+        response = client.get('/assigned-with-yield?user=foo')
+        assert response.status_code == 200
+        assert isinstance(response.json().get('id'), str)
+        assert response.json().get('id') == 'foo'
 
 
 @pytest.mark.skipif(sys.version_info < (3, 9), reason='requires python3.9 or higher')
@@ -212,27 +210,26 @@ def test_handler_can_inject_functional_deps_annotations() -> None:
                          dependencies
     """
     app = Pest.create(FunctionsDependenciesModule39plus)
-    client = TestClient(app)
+    with TestClient(app) as client:
+        response = client.get('/assigned')
+        assert response.status_code == 200
+        assert isinstance(response.json().get('id'), str)
+        assert len(response.json().get('id')) > 0
 
-    response = client.get('/assigned')
-    assert response.status_code == 200
-    assert isinstance(response.json().get('id'), str)
-    assert len(response.json().get('id')) > 0
+        # function dependencies should also be able to get query params
+        response = client.get('/assigned?user=foo')
+        assert response.status_code == 200
+        assert isinstance(response.json().get('id'), str)
+        assert response.json().get('id') == 'foo'
 
-    # function dependencies should also be able to get query params
-    response = client.get('/assigned?user=foo')
-    assert response.status_code == 200
-    assert isinstance(response.json().get('id'), str)
-    assert response.json().get('id') == 'foo'
+        # should also work with generators
+        response = client.get('/assigned-with-yield')
+        assert response.status_code == 200
+        assert isinstance(response.json().get('id'), str)
+        assert len(response.json().get('id')) > 0
 
-    # should also work with generators
-    response = client.get('/assigned-with-yield')
-    assert response.status_code == 200
-    assert isinstance(response.json().get('id'), str)
-    assert len(response.json().get('id')) > 0
-
-    # generator function dependencies should also be able to get query params
-    response = client.get('/assigned-with-yield?user=foo')
-    assert response.status_code == 200
-    assert isinstance(response.json().get('id'), str)
-    assert response.json().get('id') == 'foo'
+        # generator function dependencies should also be able to get query params
+        response = client.get('/assigned-with-yield?user=foo')
+        assert response.status_code == 200
+        assert isinstance(response.json().get('id'), str)
+        assert response.json().get('id') == 'foo'

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,0 +1,52 @@
+# from typing import Tuple, TypeAlias
+
+# import pytest
+# from fastapi.testclient import TestClient
+
+# from pest import (
+#     OnApplicationBootstrap,
+#     OnModuleInit,
+#     Pest,
+#     controller,
+#     get,
+#     module,
+# )
+# from pest.core.application import PestApplication
+
+
+# @controller('/foo')
+# class FooController(OnModuleInit, OnApplicationBootstrap):
+#     @get('/')
+#     def foo(self) -> dict:
+#         return {'message': 'Hello!'}
+
+
+# @module(controllers=[FooController])
+# class AppModule:
+#     pass
+
+
+# def bootstrap_app() -> PestApplication:
+#     app = Pest.create(root_module=AppModule)
+#     return app
+
+
+# TestApp: TypeAlias = Tuple[PestApplication, TestClient]
+
+
+# @pytest.fixture()
+# def lifecycle_app() -> TestApp:
+#     app = bootstrap_app()
+#     with TestClient(app) as client:
+#         return app, client
+
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_something() -> None:
+    # app = await bootstrap_app()
+
+    # print(app)
+    pass

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,52 +1,226 @@
-# from typing import Tuple, TypeAlias
-
-# import pytest
-# from fastapi.testclient import TestClient
-
-# from pest import (
-#     OnApplicationBootstrap,
-#     OnModuleInit,
-#     Pest,
-#     controller,
-#     get,
-#     module,
-# )
-# from pest.core.application import PestApplication
-
-
-# @controller('/foo')
-# class FooController(OnModuleInit, OnApplicationBootstrap):
-#     @get('/')
-#     def foo(self) -> dict:
-#         return {'message': 'Hello!'}
-
-
-# @module(controllers=[FooController])
-# class AppModule:
-#     pass
-
-
-# def bootstrap_app() -> PestApplication:
-#     app = Pest.create(root_module=AppModule)
-#     return app
-
-
-# TestApp: TypeAlias = Tuple[PestApplication, TestClient]
-
-
-# @pytest.fixture()
-# def lifecycle_app() -> TestApp:
-#     app = bootstrap_app()
-#     with TestClient(app) as client:
-#         return app, client
-
+from typing import Any, Coroutine, List
 
 import pytest
+from fastapi.testclient import TestClient
+
+from pest import (
+    OnApplicationBootstrap,
+    OnModuleInit,
+    Pest,
+    ValueProvider,
+    controller,
+    get,
+    module,
+)
+from pest.core.application import PestApplication
+
+# Tracking the order of lifecycle hook calls
+LIFECYCLE_CALLS: List[str] = []
+
+
+@controller('/foo')
+class FooController(OnModuleInit, OnApplicationBootstrap):
+    def on_module_init(self) -> None | Coroutine[Any, Any, None]:
+        LIFECYCLE_CALLS.append('FooController.on_module_init')
+
+    def on_application_bootstrap(self) -> None | Coroutine[Any, Any, None]:
+        LIFECYCLE_CALLS.append('FooController.on_application_bootstrap')
+
+    @get('/')
+    def foo(self) -> dict:
+        return {'message': 'Hello!'}
+
+
+class FooService(OnModuleInit, OnApplicationBootstrap):
+    def on_module_init(self) -> None | Coroutine[Any, Any, None]:
+        LIFECYCLE_CALLS.append('FooService.on_module_init')
+
+    def on_application_bootstrap(self) -> None | Coroutine[Any, Any, None]:
+        LIFECYCLE_CALLS.append('FooService.on_application_bootstrap')
+
+
+@module(
+    controllers=[FooController],
+    providers=[ValueProvider(provide=FooService, use_value=FooService())],
+)
+class AppModule(OnModuleInit, OnApplicationBootstrap):
+    def on_module_init(self) -> None | Coroutine[Any, Any, None]:
+        LIFECYCLE_CALLS.append('AppModule.on_module_init')
+
+    def on_application_bootstrap(self) -> None | Coroutine[Any, Any, None]:
+        LIFECYCLE_CALLS.append('AppModule.on_application_bootstrap')
+
+
+@controller('/bar')
+class BarController(OnModuleInit, OnApplicationBootstrap):
+    def on_module_init(self) -> None | Coroutine[Any, Any, None]:
+        LIFECYCLE_CALLS.append('BarController.on_module_init')
+
+    def on_application_bootstrap(self) -> None | Coroutine[Any, Any, None]:
+        LIFECYCLE_CALLS.append('BarController.on_application_bootstrap')
+
+    @get('/')
+    def bar(self) -> dict:
+        return {'message': 'Bar!'}
+
+
+class BarService(OnModuleInit, OnApplicationBootstrap):
+    def on_module_init(self) -> None | Coroutine[Any, Any, None]:
+        LIFECYCLE_CALLS.append('BarService.on_module_init')
+
+    def on_application_bootstrap(self) -> None | Coroutine[Any, Any, None]:
+        LIFECYCLE_CALLS.append('BarService.on_application_bootstrap')
+
+
+@module(
+    controllers=[BarController],
+    providers=[ValueProvider(provide=BarService, use_value=BarService())],
+    exports=[BarService],
+)
+class ChildModule(OnModuleInit, OnApplicationBootstrap):
+    def on_module_init(self) -> None | Coroutine[Any, Any, None]:
+        LIFECYCLE_CALLS.append('ChildModule.on_module_init')
+
+    def on_application_bootstrap(self) -> None | Coroutine[Any, Any, None]:
+        LIFECYCLE_CALLS.append('ChildModule.on_application_bootstrap')
+
+
+@module(
+    imports=[ChildModule],
+    controllers=[FooController],
+    providers=[ValueProvider(provide=FooService, use_value=FooService())],
+)
+class RootModule(OnModuleInit, OnApplicationBootstrap):
+    def on_module_init(self) -> None | Coroutine[Any, Any, None]:
+        LIFECYCLE_CALLS.append('RootModule.on_module_init')
+
+    def on_application_bootstrap(self) -> None | Coroutine[Any, Any, None]:
+        LIFECYCLE_CALLS.append('RootModule.on_application_bootstrap')
+
+
+@pytest.fixture(autouse=True)
+def clear_lifecycle_calls():
+    LIFECYCLE_CALLS.clear()
+    yield
+
+
+@pytest.fixture()
+def simple_app() -> tuple[PestApplication, TestClient]:
+    app = Pest.create(root_module=AppModule)
+    with TestClient(app) as client:
+        return app, client
+
+
+@pytest.fixture()
+def nested_app() -> tuple[PestApplication, TestClient]:
+    app = Pest.create(root_module=RootModule)
+    with TestClient(app) as client:
+        return app, client
 
 
 @pytest.mark.asyncio
-async def test_something() -> None:
-    # app = await bootstrap_app()
+async def test_simple_app_lifecycle_hooks(simple_app) -> None:
+    """🐀 lifecycle :: hooks :: should be called in correct order in simple app"""
+    app, client = simple_app
 
-    # print(app)
-    pass
+    # Test that all endpoints work
+    response = client.get('/foo/')
+    assert response.status_code == 200
+    assert response.json() == {'message': 'Hello!'}
+
+    # Verify lifecycle hooks were called in correct order
+    assert LIFECYCLE_CALLS == [
+        # Module Init Phase
+        'FooService.on_module_init',  # First providers
+        'FooController.on_module_init',  # Then controllers
+        'AppModule.on_module_init',  # Finally the module itself
+        # Application Bootstrap Phase
+        'FooService.on_application_bootstrap',  # First providers
+        'FooController.on_application_bootstrap',  # Then controllers
+        'AppModule.on_application_bootstrap',  # Finally the module itself
+    ]
+
+
+@pytest.mark.asyncio
+async def test_nested_modules_lifecycle_hooks(nested_app) -> None:
+    """🐀 lifecycle :: hooks :: should be called in correct order with nested modules"""
+    app, client = nested_app
+
+    # Test that all endpoints work
+    response = client.get('/foo/')
+    assert response.status_code == 200
+    assert response.json() == {'message': 'Hello!'}
+
+    response = client.get('/bar/')
+    assert response.status_code == 200
+    assert response.json() == {'message': 'Bar!'}
+
+    # Verify lifecycle hooks were called in correct order
+    assert LIFECYCLE_CALLS == [
+        # Child Module Init Phase
+        'BarService.on_module_init',  # Child module providers
+        'BarController.on_module_init',  # Child module controllers
+        'ChildModule.on_module_init',  # Child module itself
+        # Root Module Init Phase
+        'FooService.on_module_init',  # Root module providers
+        'FooController.on_module_init',  # Root module controllers
+        'RootModule.on_module_init',  # Root module itself
+        # Application Bootstrap Phase (bottom-up)
+        'BarService.on_application_bootstrap',  # Child providers
+        'BarController.on_application_bootstrap',  # Child controllers
+        'ChildModule.on_application_bootstrap',  # Child module
+        'FooService.on_application_bootstrap',  # Root providers
+        'FooController.on_application_bootstrap',  # Root controllers
+        'RootModule.on_application_bootstrap',  # Root module
+    ]
+
+
+@pytest.mark.asyncio
+async def test_async_lifecycle_hooks() -> None:
+    """🐀 lifecycle :: hooks :: should work with async lifecycle hooks"""
+    LIFECYCLE_CALLS.clear()
+
+    @controller('/async')
+    class AsyncController(OnModuleInit, OnApplicationBootstrap):
+        async def on_module_init(self) -> None:
+            LIFECYCLE_CALLS.append('AsyncController.on_module_init')
+
+        async def on_application_bootstrap(self) -> None:
+            LIFECYCLE_CALLS.append('AsyncController.on_application_bootstrap')
+
+        @get('/')
+        def handler(self) -> dict:
+            return {'message': 'Async!'}
+
+    class AsyncService(OnModuleInit, OnApplicationBootstrap):
+        async def on_module_init(self) -> None:
+            LIFECYCLE_CALLS.append('AsyncService.on_module_init')
+
+        async def on_application_bootstrap(self) -> None:
+            LIFECYCLE_CALLS.append('AsyncService.on_application_bootstrap')
+
+    @module(
+        controllers=[AsyncController],
+        providers=[ValueProvider(provide=AsyncService, use_value=AsyncService())],
+    )
+    class AsyncModule(OnModuleInit, OnApplicationBootstrap):
+        async def on_module_init(self) -> None:
+            LIFECYCLE_CALLS.append('AsyncModule.on_module_init')
+
+        async def on_application_bootstrap(self) -> None:
+            LIFECYCLE_CALLS.append('AsyncModule.on_application_bootstrap')
+
+    app = Pest.create(root_module=AsyncModule)
+    with TestClient(app) as client:
+        response = client.get('/async/')
+        assert response.status_code == 200
+        assert response.json() == {'message': 'Async!'}
+
+        assert LIFECYCLE_CALLS == [
+            'AsyncService.on_module_init',
+            'AsyncController.on_module_init',
+            'AsyncModule.on_module_init',
+            'AsyncService.on_application_bootstrap',
+            'AsyncController.on_application_bootstrap',
+            'AsyncModule.on_application_bootstrap',
+        ]

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,4 +1,9 @@
-from typing import Any, Coroutine, List
+from typing import Any, List, Optional
+
+try:
+    from typing import Coroutine
+except ImportError:
+    from typing_extensions import Coroutine
 
 import pytest
 from fastapi.testclient import TestClient
@@ -20,10 +25,10 @@ LIFECYCLE_CALLS: List[str] = []
 
 @controller('/foo')
 class FooController(OnModuleInit, OnApplicationBootstrap):
-    def on_module_init(self) -> None | Coroutine[Any, Any, None]:
+    def on_module_init(self) -> Optional[Coroutine[Any, Any, None]]:
         LIFECYCLE_CALLS.append('FooController.on_module_init')
 
-    def on_application_bootstrap(self) -> None | Coroutine[Any, Any, None]:
+    def on_application_bootstrap(self) -> Optional[Coroutine[Any, Any, None]]:
         LIFECYCLE_CALLS.append('FooController.on_application_bootstrap')
 
     @get('/')
@@ -32,10 +37,10 @@ class FooController(OnModuleInit, OnApplicationBootstrap):
 
 
 class FooService(OnModuleInit, OnApplicationBootstrap):
-    def on_module_init(self) -> None | Coroutine[Any, Any, None]:
+    def on_module_init(self) -> Optional[Coroutine[Any, Any, None]]:
         LIFECYCLE_CALLS.append('FooService.on_module_init')
 
-    def on_application_bootstrap(self) -> None | Coroutine[Any, Any, None]:
+    def on_application_bootstrap(self) -> Optional[Coroutine[Any, Any, None]]:
         LIFECYCLE_CALLS.append('FooService.on_application_bootstrap')
 
 
@@ -44,19 +49,19 @@ class FooService(OnModuleInit, OnApplicationBootstrap):
     providers=[ValueProvider(provide=FooService, use_value=FooService())],
 )
 class AppModule(OnModuleInit, OnApplicationBootstrap):
-    def on_module_init(self) -> None | Coroutine[Any, Any, None]:
+    def on_module_init(self) -> Optional[Coroutine[Any, Any, None]]:
         LIFECYCLE_CALLS.append('AppModule.on_module_init')
 
-    def on_application_bootstrap(self) -> None | Coroutine[Any, Any, None]:
+    def on_application_bootstrap(self) -> Optional[Coroutine[Any, Any, None]]:
         LIFECYCLE_CALLS.append('AppModule.on_application_bootstrap')
 
 
 @controller('/bar')
 class BarController(OnModuleInit, OnApplicationBootstrap):
-    def on_module_init(self) -> None | Coroutine[Any, Any, None]:
+    def on_module_init(self) -> Optional[Coroutine[Any, Any, None]]:
         LIFECYCLE_CALLS.append('BarController.on_module_init')
 
-    def on_application_bootstrap(self) -> None | Coroutine[Any, Any, None]:
+    def on_application_bootstrap(self) -> Optional[Coroutine[Any, Any, None]]:
         LIFECYCLE_CALLS.append('BarController.on_application_bootstrap')
 
     @get('/')
@@ -65,10 +70,10 @@ class BarController(OnModuleInit, OnApplicationBootstrap):
 
 
 class BarService(OnModuleInit, OnApplicationBootstrap):
-    def on_module_init(self) -> None | Coroutine[Any, Any, None]:
+    def on_module_init(self) -> Optional[Coroutine[Any, Any, None]]:
         LIFECYCLE_CALLS.append('BarService.on_module_init')
 
-    def on_application_bootstrap(self) -> None | Coroutine[Any, Any, None]:
+    def on_application_bootstrap(self) -> Optional[Coroutine[Any, Any, None]]:
         LIFECYCLE_CALLS.append('BarService.on_application_bootstrap')
 
 
@@ -78,10 +83,10 @@ class BarService(OnModuleInit, OnApplicationBootstrap):
     exports=[BarService],
 )
 class ChildModule(OnModuleInit, OnApplicationBootstrap):
-    def on_module_init(self) -> None | Coroutine[Any, Any, None]:
+    def on_module_init(self) -> Optional[Coroutine[Any, Any, None]]:
         LIFECYCLE_CALLS.append('ChildModule.on_module_init')
 
-    def on_application_bootstrap(self) -> None | Coroutine[Any, Any, None]:
+    def on_application_bootstrap(self) -> Optional[Coroutine[Any, Any, None]]:
         LIFECYCLE_CALLS.append('ChildModule.on_application_bootstrap')
 
 
@@ -91,10 +96,10 @@ class ChildModule(OnModuleInit, OnApplicationBootstrap):
     providers=[ValueProvider(provide=FooService, use_value=FooService())],
 )
 class RootModule(OnModuleInit, OnApplicationBootstrap):
-    def on_module_init(self) -> None | Coroutine[Any, Any, None]:
+    def on_module_init(self) -> Optional[Coroutine[Any, Any, None]]:
         LIFECYCLE_CALLS.append('RootModule.on_module_init')
 
-    def on_application_bootstrap(self) -> None | Coroutine[Any, Any, None]:
+    def on_application_bootstrap(self) -> Optional[Coroutine[Any, Any, None]]:
         LIFECYCLE_CALLS.append('RootModule.on_application_bootstrap')
 
 

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,5 +1,6 @@
 from typing import cast
 
+import pytest
 from dij import Container
 from pytest import raises
 
@@ -74,9 +75,10 @@ def test_module_meta():
     assert meta['exports'][0] == FakeProvider
 
 
-def test_module_setup():
+@pytest.mark.asyncio
+async def test_module_setup():
     """🐀 modules :: setup_module :: should initialize a module"""
-    mod = _setup_module(Mod)
+    mod = await _setup_module(Mod)
 
     # check it's an instance of Mod and also of Module
     assert isinstance(mod, Mod)
@@ -86,7 +88,8 @@ def test_module_setup():
     assert status(mod) == Status.READY
 
 
-def test_module_container(mod: Mod):
+@pytest.mark.asyncio
+async def test_module_container(mod):
     """🐀 modules :: module.container :: module should have its own container"""
     container: Container = cast(Container, getattr(mod, 'container', None))
     assert container is not None
@@ -138,11 +141,12 @@ def test_di_module_with_controller(module_with_controller: Module):
     assert baz_svc.do_the_baz() == 'baz'
 
 
-def test_module_with_children_setup():
+@pytest.mark.asyncio
+async def test_module_with_children_setup():
     """🐀 modules :: setup_module (with-children) ::
     should initialize the module and its children
     """
-    parent_mod = _setup_module(ParentMod)
+    parent_mod = await _setup_module(ParentMod)
 
     # check it's an instance of ParentMod and also of Module
     assert isinstance(parent_mod, ParentMod)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
 
+import pytest
+
 from pest.core.module import setup_module as _setup_module
 from pest.exceptions.http.http import exc_response
 from pest.metadata.meta import get_meta, get_meta_value
@@ -26,9 +28,10 @@ def test_colorize_no_color_option():
     assert colored == '🤠 > Howdy, Cowboy!'
 
 
-def test_module_tree_generation():
+@pytest.mark.asyncio
+async def test_module_tree_generation():
     """🐀 utils :: module :: should generate a tree representation of a module"""
-    module = _setup_module(FooModule)
+    module = await _setup_module(FooModule)
 
     tree = as_tree(module)
 


### PR DESCRIPTION
## 🚀 Add Module Lifecycle Hooks

This PR introduces lifecycle hooks for modules, controllers and providers in Pest applications. The hooks enable running code at specific points during the application lifecycle.

### New Features
- Added `OnModuleInit` interface for initialization logic when modules are first created
- Added `OnApplicationBootstrap` interface for logic that runs when the app is ready
- Support for both sync and async hook implementations

## Example Usage
```python
@module(
    controllers=[MyController],
    providers=[MyService]
)
class AppModule(OnModuleInit, OnApplicationBootstrap):
    def on_module_init(self):
        # Run initialization logic
        pass
        
    def on_application_bootstrap(self):
        # Run bootstrap logic when app is ready
        pass
```